### PR TITLE
Rename test executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,8 @@ target_include_directories(tensorboard_logger PUBLIC
     ${PROJECT_SOURCE_DIR}/include
     ${Protobuf_INCLUDE_DIRS}
     ${PROJECT_BINARY_DIR}
-    )
+)
 target_link_libraries(tensorboard_logger PUBLIC ${Protobuf_LIBRARIES})
 
-add_executable(test
-    tests/test_tensorboard_logger.cc
-)
-target_link_libraries(test tensorboard_logger)
+add_executable(tensorboard_logger_test tests/test_tensorboard_logger.cc)
+target_link_libraries(tensorboard_logger_test tensorboard_logger)


### PR DESCRIPTION
Renamed the test executable to a tensorboard_logger unique name, as to not cause clashes.