### PR TITLE
Default resume flag for truncating vs appending

### DIFF
--- a/include/tensorboard_logger.h
+++ b/include/tensorboard_logger.h
@@ -21,10 +21,12 @@ const std::string kTextPluginName = "text";
 
 class TensorBoardLogger {
    public:
-    explicit TensorBoardLogger(const char *log_file) {
+    explicit TensorBoardLogger(const char *log_file, bool resume = false) {
         bucket_limits_ = nullptr;
         ofs_ = new std::ofstream(
-            log_file, std::ios::out | std::ios::trunc | std::ios::binary);
+            log_file, std::ios::out |
+                          (resume ? std::ios::app : std::ios::trunc) |
+                          std::ios::binary);
         if (!ofs_->is_open())
             throw std::runtime_error("failed to open log_file " +
                                      std::string(log_file));


### PR DESCRIPTION
Adds an additional constructor argument for a resume flag, which defaults to false to not change any existing references, following #18. If `resume` is true, the `trunc` bit flag will be replaced with `app` so that additional metric calls will be appended rather than added to the beginning. 

This allows for other codebases to pause/resume, and still log to the same tensorboard tracked file.