### PR TITLE
Don't force shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ file(GLOB protos "proto/*.proto")
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ${protos})
 
-add_library(tensorboard_logger SHARED
+add_library(tensorboard_logger
     "src/crc.cc"
     "src/tensorboard_logger.cc"
     ${PROTO_SRCS}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ To build and install TensorBoard Logger with cmake:
 > cmake --install $BUILD_DIR
 ```
 
+Alternatively to build a shared library set `BUILD_SHARED_LIBS=ON`:
+
+```bash
+> BUILD_DIR=build
+> mkdir -p $BUILD_DIR && cmake -B $BUILD_DIR -DBUILD_SHARED_LIBS=ON . && cmake --build $BUILD_DIR -j
+> cmake --install $BUILD_DIR
+```
+
 Then use `find_package(tensorboard_logger REQUIRED)` in your project.
 
 Alternatively use via cmake FetchContent:


### PR DESCRIPTION
Rather than forcing a shared or static library, allow the user to set the `BUILD_SHARED_LIBS` variable in cmake to switch accordingly.